### PR TITLE
Charging windows fix

### DIFF
--- a/bundles/org.openhab.binding.mybmw/README.md
+++ b/bundles/org.openhab.binding.mybmw/README.md
@@ -171,7 +171,7 @@ Reflects overall status of the vehicle.
 | Check Control             | check-control       | String        | Presence of active warning messages            |  X   |  X   |    X    |  X  |
 | Plug Connection Status    | plug-connection     | String        | Plug is _Connected_ or _Not connected_         |      |  X   |    X    |  X  |
 | Charging Status           | charge              | String        | Current charging status                        |      |  X   |    X    |  X  |
-| Charging Information      | charge-info         | String        | Information regarding current charging session |      |  X   |    X    |  X  |
+| Remaining Charging Time   | charge-remaining    | Number:Time   | Remainining time for current charging session  |      |  X   |    X    |  X  |
 | Last Status Timestamp     | last-update         | DateTime      | Date and time of last status update            |  X   |  X   |    X    |  X  |
 
 Overall Door Status values
@@ -364,13 +364,14 @@ Parallel execution isn't supported.
 
 The channel _command_ provides options
 
-* _ight-flash_
+* _light-flash_
 * _vehicle-finder_
 * _door-lock_
 * _door-unlock_
 * _horn-blow_
 * _climate-now-start_
 * _climate-now-stop_
+* _charge-now_
 
 The channel _state_ shows the progress of the command execution in the following order
 

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/MyBMWConstants.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/MyBMWConstants.java
@@ -126,7 +126,7 @@ public class MyBMWConstants {
     public static final String CHECK_CONTROL = "check-control";
     public static final String PLUG_CONNECTION = "plug-connection";
     public static final String CHARGE_STATUS = "charge";
-    public static final String CHARGE_INFO = "charge-info";
+    public static final String CHARGE_REMAINING = "charge-remaining";
     public static final String LAST_UPDATE = "last-update";
     public static final String RAW = "raw";
 

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
@@ -115,7 +115,7 @@ public class MyBMWCommandExtension extends AbstractConsoleCommandExtension {
 
                             if (args.length == 3) {
                                 Optional<VehicleBase> vehicleOptional = vehicles.stream()
-                                        .filter(v -> v.getVin().equals(args[2])).findAny();
+                                        .filter(v -> v.getVin().toLowerCase().equals(args[2].toLowerCase())).findAny();
                                 if (vehicleOptional.isEmpty()) {
                                     console.println(
                                             "'" + args[2] + "' is not a valid vin on the account bridge with id '"

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.mybmw.internal.console;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.mybmw.internal.dto.network.NetworkException;
+import org.openhab.binding.mybmw.internal.dto.vehicle.VehicleBase;
+import org.openhab.binding.mybmw.internal.handler.MyBMWBridgeHandler;
+import org.openhab.binding.mybmw.internal.handler.backend.ResponseContentAnonymizer;
+import org.openhab.binding.mybmw.internal.utils.BimmerConstants;
+import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link MyBMWCommandExtension} is responsible for handling console commands
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+
+@NonNullByDefault
+@Component(service = ConsoleCommandExtension.class)
+public class MyBMWCommandExtension extends AbstractConsoleCommandExtension {
+
+    private static final String ACCOUNTS = "accounts";
+    private static final String FINGERPRINT = "fingerprint";
+
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public MyBMWCommandExtension(final @Reference ThingRegistry thingRegistry) {
+        super("mybmw", "Interact with the MyBMW binding");
+        this.thingRegistry = thingRegistry;
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if ((args.length < 1) || (args.length > 3)) {
+            console.println("Invalid number of arguments");
+            printUsage(console);
+            return;
+        }
+
+        List<MyBMWBridgeHandler> bridgeHandlers = thingRegistry.getAll().stream()
+                .filter(t -> t.getHandler() instanceof MyBMWBridgeHandler)
+                .map(b -> ((MyBMWBridgeHandler) b.getHandler())).collect(Collectors.toList());
+        if (bridgeHandlers.isEmpty()) {
+            console.println("No account bridges configured");
+            return;
+        }
+
+        if (ACCOUNTS.equals(args[0])) {
+            if (args.length == 1) {
+                bridgeHandlers.forEach(b -> console.printf("%s - %s%n", b.getThing().getUID().getId(),
+                        b.getThing().getConfiguration().get("userName")));
+            } else {
+                console.println("No extra argument allowed after 'accounts'");
+                printUsage(console);
+            }
+        } else if (FINGERPRINT.equals(args[0])) {
+            List<MyBMWBridgeHandler> handlers;
+            if (args.length > 1) {
+                Optional<MyBMWBridgeHandler> bridgeOptional = bridgeHandlers.stream()
+                        .filter(b -> b.getThing().getUID().getId().equals(args[1])).findAny();
+                if (bridgeOptional.isEmpty()) {
+                    console.println("'" + args[1] + "' is not a valid id for a myBMW account bridge");
+                    printUsage(console);
+                    return;
+                }
+                handlers = List.of(bridgeOptional.get());
+            } else {
+                handlers = bridgeHandlers;
+            }
+
+            console.println("# Start fingerprint");
+            int accountNdx = 0;
+            for (MyBMWBridgeHandler handler : handlers) {
+                accountNdx++;
+                console.println("### Start account " + String.valueOf(accountNdx));
+                if (!ThingStatus.ONLINE.equals(handler.getThing().getStatus())) {
+                    console.println("MyBMW bridge for account not online, cannot create fingerprint");
+                } else {
+                    handler.getProxy().ifPresentOrElse(prox -> {
+                        // get list of vehicles
+                        List<@NonNull VehicleBase> vehicles = null;
+                        try {
+                            vehicles = prox.requestVehiclesBase();
+
+                            for (String brand : BimmerConstants.REQUESTED_BRANDS) {
+                                console.println("###### Vehicles base for brand " + brand);
+                                console.println(ResponseContentAnonymizer
+                                        .anonymizeResponseContent(prox.requestVehiclesBaseJson(brand)));
+                            }
+
+                            if (args.length == 3) {
+                                Optional<VehicleBase> vehicleOptional = vehicles.stream()
+                                        .filter(v -> v.getVin().equals(args[2])).findAny();
+                                if (vehicleOptional.isEmpty()) {
+                                    console.println(
+                                            "'" + args[2] + "' is not a valid vin on the account bridge with id '"
+                                                    + handler.getThing().getUID().getId() + "'");
+                                    printUsage(console);
+                                    return;
+                                }
+                                vehicles = List.of(vehicleOptional.get());
+                            }
+
+                            int vehicleNdx = 0;
+                            for (VehicleBase vehicleBase : vehicles) {
+                                vehicleNdx++;
+                                console.println("###### Start vehicle " + String.valueOf(vehicleNdx));
+                                // get state
+                                console.println("######## Vehicle state");
+                                console.println(
+                                        ResponseContentAnonymizer.anonymizeResponseContent(prox.requestVehicleStateJson(
+                                                vehicleBase.getVin(), vehicleBase.getAttributes().getBrand())));
+
+                                // get charge statistics -> only successful for electric vehicles
+                                console.println("######### Vehicle charging statistics");
+                                console.println(ResponseContentAnonymizer
+                                        .anonymizeResponseContent(prox.requestChargeStatisticsJson(vehicleBase.getVin(),
+                                                vehicleBase.getAttributes().getBrand())));
+
+                                console.println("######### Vehicle charging sessions");
+                                console.println(ResponseContentAnonymizer
+                                        .anonymizeResponseContent(prox.requestChargeSessionsJson(vehicleBase.getVin(),
+                                                vehicleBase.getAttributes().getBrand())));
+                                console.println("###### End vehicle " + String.valueOf(vehicleNdx));
+                            }
+                        } catch (NetworkException e) {
+                            console.println("Fingerprint failed, network exception: " + e.getReason());
+                        }
+                    }, () -> {
+                        console.println("MyBMW bridge with id '" + handler.getThing().getUID().getId()
+                                + "', communication not started, cannot retrieve fingerprint");
+                    });
+                }
+                console.println("### End account " + String.valueOf(accountNdx));
+            }
+            console.println("# End fingerprint");
+        } else {
+            console.println("Unsupported command '" + args[0] + "'");
+            printUsage(console);
+        }
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays.asList(new String[] { buildCommandUsage(ACCOUNTS, "list bridgeIds for accounts"),
+                buildCommandUsage(FINGERPRINT, "generate fingerprint for all vehicles on all account bridges"),
+                buildCommandUsage(FINGERPRINT + " <bridgeId>", "generate fingerprint for vehicles on account bridge"),
+                buildCommandUsage(FINGERPRINT + " <bridgeId> <vin>",
+                        "generate fingerprint for vehicle with vin on account bridge") });
+    }
+}

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSession.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSession.java
@@ -12,16 +12,17 @@
  */
 package org.openhab.binding.mybmw.internal.dto.charge;
 
-import java.util.List;
-
 /**
- * The {@link ChargeSessions} Data Transfer Object
+ * The {@link ChargingSession} Data Transfer Object
  *
  * @author Bernd Weymann - Initial contribution
  */
-public class ChargeSessions {
-    public String total;// ": "~ 218 kWh",
-    public String numberOfSessions;// ": "17",
-    public String chargingListState;// ": "HAS_SESSIONS",
-    public List<ChargeSession> sessions;
+public class ChargingSession {
+    public String id;// ": "2021-12-26T16:57:20Z_128fa4af",
+    public String title;// ": "Gestern 17:57",
+    public String subtitle;// ": "Uferstraße 4B • 7h 45min • -- EUR",
+    public String energyCharged;// ": "~ 31 kWh",
+    public String sessionStatus;// ": "FINISHED",
+    public String issues;// ": "2 Probleme",
+    public String isPublic;// ": false
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSessions.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSessions.java
@@ -12,17 +12,16 @@
  */
 package org.openhab.binding.mybmw.internal.dto.charge;
 
+import java.util.List;
+
 /**
- * The {@link ChargeSession} Data Transfer Object
+ * The {@link ChargingSessions} Data Transfer Object
  *
  * @author Bernd Weymann - Initial contribution
  */
-public class ChargeSession {
-    public String id;// ": "2021-12-26T16:57:20Z_128fa4af",
-    public String title;// ": "Gestern 17:57",
-    public String subtitle;// ": "Uferstraße 4B • 7h 45min • -- EUR",
-    public String energyCharged;// ": "~ 31 kWh",
-    public String sessionStatus;// ": "FINISHED",
-    public String issues;// ": "2 Probleme",
-    public String isPublic;// ": false
+public class ChargingSessions {
+    public String total;// ": "~ 218 kWh",
+    public String numberOfSessions;// ": "17",
+    public String chargingListState;// ": "HAS_SESSIONS",
+    public List<ChargingSession> sessions;
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSessionsContainer.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingSessionsContainer.java
@@ -13,14 +13,11 @@
 package org.openhab.binding.mybmw.internal.dto.charge;
 
 /**
- * The {@link ChargeStatistics} Data Transfer Object
+ * The {@link ChargingSessionsContainer} Data Transfer Object
  *
  * @author Bernd Weymann - Initial contribution
  */
-public class ChargeStatistics {
-    public int totalEnergyCharged;// ": 173,
-    public String totalEnergyChargedSemantics;// ": "Insgesamt circa 173 Kilowattstunden geladen",
-    public String symbol;// ": "~",
-    public int numberOfChargingSessions;// ": 13,
-    public String numberOfChargingSessionsSemantics;// ": "13 Ladevorgänge"
+public class ChargingSessionsContainer {
+    public Object paginationInfo;
+    public ChargingSessions chargingSessions;
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingStatistics.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingStatistics.java
@@ -13,11 +13,14 @@
 package org.openhab.binding.mybmw.internal.dto.charge;
 
 /**
- * The {@link ChargeSessionsContainer} Data Transfer Object
+ * The {@link ChargingStatistics} Data Transfer Object
  *
  * @author Bernd Weymann - Initial contribution
  */
-public class ChargeSessionsContainer {
-    public Object paginationInfo;
-    public ChargeSessions chargingSessions;
+public class ChargingStatistics {
+    public int totalEnergyCharged;// ": 173,
+    public String totalEnergyChargedSemantics;// ": "Insgesamt circa 173 Kilowattstunden geladen",
+    public String symbol;// ": "~",
+    public int numberOfChargingSessions;// ": 13,
+    public String numberOfChargingSessionsSemantics;// ": "13 Ladevorgänge"
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingStatisticsContainer.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/charge/ChargingStatisticsContainer.java
@@ -13,12 +13,12 @@
 package org.openhab.binding.mybmw.internal.dto.charge;
 
 /**
- * The {@link ChargeStatisticsContainer} Data Transfer Object
+ * The {@link ChargingStatisticsContainer} Data Transfer Object
  *
  * @author Bernd Weymann - Initial contribution
  */
-public class ChargeStatisticsContainer {
+public class ChargingStatisticsContainer {
     public String description;// ": "Dezember 2021",
     public String optStateType;// ": "OPT_IN_WITH_SESSIONS",
-    public ChargeStatistics statistics;// ": {
+    public ChargingStatistics statistics;// ": {
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/ElectricChargingState.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/ElectricChargingState.java
@@ -17,6 +17,7 @@ package org.openhab.binding.mybmw.internal.dto.vehicle;
  * derived from the API responses
  *
  * @author Martin Grassl - initial contribution
+ * @author Mark Herwege - refactoring, V2 API charging 
  */
 public class ElectricChargingState {
     private String chargingConnectionType = ""; // UNKNOWN,

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/ElectricChargingState.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/ElectricChargingState.java
@@ -13,9 +13,9 @@
 package org.openhab.binding.mybmw.internal.dto.vehicle;
 
 /**
- * 
+ *
  * derived from the API responses
- * 
+ *
  * @author Martin Grassl - initial contribution
  */
 public class ElectricChargingState {
@@ -24,6 +24,7 @@ public class ElectricChargingState {
     private boolean isChargerConnected = false; // true,
     private int chargingTarget = -1; // 80,
     private int chargingLevelPercent = -1; // 80,
+    private int remainingChargingMinutes = -1; // 178
     private int range = -1; // 286
 
     /**
@@ -97,6 +98,20 @@ public class ElectricChargingState {
     }
 
     /**
+     * @return the remainingChargingMinutes
+     */
+    public int getRemainingChargingMinutes() {
+        return remainingChargingMinutes;
+    }
+
+    /**
+     * @param remainingChargingMinutes the remainingChargingMinutes to set
+     */
+    public void setRemainingChargingMinutes(int remainingChargingMinutes) {
+        this.remainingChargingMinutes = remainingChargingMinutes;
+    }
+
+    /**
      * @return the range
      */
     public int getRange() {
@@ -112,7 +127,7 @@ public class ElectricChargingState {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#toString()
      */
 
@@ -120,6 +135,7 @@ public class ElectricChargingState {
     public String toString() {
         return "ElectricChargingState [chargingConnectionType=" + chargingConnectionType + ", chargingStatus="
                 + chargingStatus + ", isChargerConnected=" + isChargerConnected + ", chargingTarget=" + chargingTarget
-                + ", chargingLevelPercent=" + chargingLevelPercent + ", range=" + range + "]";
+                + ", chargingLevelPercent=" + chargingLevelPercent + ", remainingChargingMinutes="
+                + remainingChargingMinutes + ", range=" + range + "]";
     }
 }

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/VehicleAttributes.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/dto/vehicle/VehicleAttributes.java
@@ -19,6 +19,7 @@ import org.openhab.binding.mybmw.internal.utils.BimmerConstants;
  * derived from the API responses
  *
  * @author Martin Grassl - initial contribution
+ * @author Mark Herwege - fix brand BMW_I 
  */
 public class VehicleAttributes {
     private String lastFetched = ""; // "2022-12-21T17:30:40.363Z"

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
@@ -34,11 +34,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.mybmw.internal.MyBMWConstants.VehicleType;
 import org.openhab.binding.mybmw.internal.MyBMWVehicleConfiguration;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingProfile;
 import org.openhab.binding.mybmw.internal.dto.charge.ChargingSession;
 import org.openhab.binding.mybmw.internal.dto.charge.ChargingSessionsContainer;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargingProfile;
 import org.openhab.binding.mybmw.internal.dto.charge.ChargingSettings;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
 import org.openhab.binding.mybmw.internal.dto.network.NetworkException;
 import org.openhab.binding.mybmw.internal.dto.vehicle.CheckControlMessage;
 import org.openhab.binding.mybmw.internal.dto.vehicle.RequiredService;
@@ -403,8 +403,10 @@ public class VehicleHandler extends BaseThingHandler {
             updateChannel(CHANNEL_GROUP_STATUS, CHARGE_STATUS,
                     Converter.toTitleCase(vehicleState.getElectricChargingState().getChargingStatus()),
                     channelToBeUpdated);
-            // TODO: I don't know what to set here with API v2
-            updateChannel(CHANNEL_GROUP_STATUS, CHARGE_INFO, StringType.valueOf(Constants.UNDEF), channelToBeUpdated);
+            int remainingTime = vehicleState.getElectricChargingState().getRemainingChargingMinutes();
+            updateChannel(CHANNEL_GROUP_STATUS, CHARGE_REMAINING,
+                    remainingTime >= 0 ? QuantityType.valueOf(remainingTime, Units.MINUTE) : UnDefType.UNDEF,
+                    channelToBeUpdated);
         }
     }
 

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
@@ -94,7 +94,8 @@ import org.slf4j.LoggerFactory;
  * @author Bernd Weymann - Initial contribution
  * @author Norbert Truchsess - edit & send charge profile
  * @author Martin Grassl - refactoring, merge with VehicleChannelHandler
- */
+ * @author Mark Herwege - refactoring, V2 API charging 
+*/
 @NonNullByDefault
 public class VehicleHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(VehicleHandler.class);

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/VehicleHandler.java
@@ -219,7 +219,6 @@ public class VehicleHandler extends BaseThingHandler {
                     stateError = true;
                 }
 
-                // TODO: disabled charge statistics and charge sessions as the API returns an error
                 if (!stateError && isElectric) {
                     try {
                         updateChargeStatistics(prox.requestChargeStatistics(config.getVin(), config.getVehicleBrand()),

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/auth/MyBMWTokenController.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/auth/MyBMWTokenController.java
@@ -75,8 +75,7 @@ public class MyBMWTokenController {
      * Gets new token if old one is expired or invalid. In case of error the token
      * remains.
      * So if token refresh fails the corresponding requests will also fail and
-     * update the
-     * Thing status accordingly.
+     * update the Thing status accordingly.
      *
      * @return token
      */

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/auth/MyBMWTokenController.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/auth/MyBMWTokenController.java
@@ -12,41 +12,8 @@
  */
 package org.openhab.binding.mybmw.internal.handler.auth;
 
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.API_OAUTH_CONFIG;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.AUTHORIZATION_CODE;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.AUTH_PROVIDER;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.BRAND_BMW;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.CHINA_LOGIN;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.CHINA_PUBLIC_KEY;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.EADRAX_SERVER_MAP;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.LOGIN_NONCE;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.OAUTH_ENDPOINT;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.OCP_APIM_KEYS;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.REGION_CHINA;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.REGION_NORTH_AMERICA;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.REGION_ROW;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.USER_AGENT;
-import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.X_USER_AGENT;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.AUTHORIZATION;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CLIENT_ID;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CODE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CODE_CHALLENGE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CODE_CHALLENGE_METHOD;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CODE_VERIFIER;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.CONTENT_TYPE_URL_ENCODED;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.GRANT_TYPE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.HEADER_ACP_SUBSCRIPTION_KEY;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.HEADER_BMW_CORRELATION_ID;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.HEADER_X_CORRELATION_ID;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.HEADER_X_IDENTITY_PROVIDER;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.HEADER_X_USER_AGENT;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.NONCE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.PASSWORD;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.REDIRECT_URI;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.RESPONSE_TYPE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.SCOPE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.STATE;
-import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.USERNAME;
+import static org.openhab.binding.mybmw.internal.utils.BimmerConstants.*;
+import static org.openhab.binding.mybmw.internal.utils.HTTPConstants.*;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
@@ -60,6 +27,7 @@ import java.util.UUID;
 import javax.crypto.Cipher;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -81,11 +49,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 
+ *
  * requests the tokens for MyBMW API authorization
- * 
+ *
  * thanks to bimmer_connected https://github.com/bimmerconnected/bimmer_connected
- * 
+ *
  * @author Bernd Weymann - Initial contribution
  * @author Martin Grassl - extracted from myBmwProxy
  */
@@ -144,7 +112,6 @@ public class MyBMWTokenController {
      *
      * @return
      */
-    @SuppressWarnings("null")
     private synchronized boolean updateToken() {
         try {
             /*
@@ -178,7 +145,7 @@ public class MyBMWTokenController {
             String codeChallenge = generateCodeChallenge(codeVerifier);
             String state = generateState();
 
-            MultiMap<String> baseParams = new MultiMap<String>();
+            MultiMap<@Nullable String> baseParams = new MultiMap<>();
             baseParams.put(CLIENT_ID, aqr.clientId);
             baseParams.put(RESPONSE_TYPE, CODE);
             baseParams.put(REDIRECT_URI, aqr.returnUrl);
@@ -196,7 +163,7 @@ public class MyBMWTokenController {
 
             loginRequest.header(HttpHeader.CONTENT_TYPE, CONTENT_TYPE_URL_ENCODED);
 
-            MultiMap<String> loginParams = new MultiMap<String>(baseParams);
+            MultiMap<@Nullable String> loginParams = new MultiMap<>(baseParams);
             loginParams.put(GRANT_TYPE, AUTHORIZATION_CODE);
             loginParams.put(USERNAME, configuration.userName);
             loginParams.put(PASSWORD, configuration.password);
@@ -214,7 +181,7 @@ public class MyBMWTokenController {
              * Step 4) Authorize with code
              */
             Request authRequest = httpClient.POST(loginUrl).followRedirects(false);
-            MultiMap<String> authParams = new MultiMap<String>(baseParams);
+            MultiMap<@Nullable String> authParams = new MultiMap<>(baseParams);
             authParams.put(AUTHORIZATION, authCode);
             authRequest.header(HttpHeader.CONTENT_TYPE, CONTENT_TYPE_URL_ENCODED);
             authRequest.content(new StringContentProvider(CONTENT_TYPE_URL_ENCODED,
@@ -235,7 +202,7 @@ public class MyBMWTokenController {
             codeRequest.header(HttpHeader.CONTENT_TYPE, CONTENT_TYPE_URL_ENCODED);
             codeRequest.header(AUTHORIZATION, basicAuth);
 
-            MultiMap<String> codeParams = new MultiMap<String>();
+            MultiMap<@Nullable String> codeParams = new MultiMap<>();
             codeParams.put(CODE, code);
             codeParams.put(CODE_VERIFIER, codeVerifier);
             codeParams.put(REDIRECT_URI, aqr.returnUrl);
@@ -288,13 +255,13 @@ public class MyBMWTokenController {
     }
 
     private String codeFromUrl(String encodedUrl) {
-        final MultiMap<String> tokenMap = new MultiMap<String>();
+        final MultiMap<@Nullable String> tokenMap = new MultiMap<>();
         UrlEncoded.decodeTo(encodedUrl, tokenMap, StandardCharsets.US_ASCII);
         final StringBuilder codeFound = new StringBuilder();
         tokenMap.forEach((key, value) -> {
             if (value.size() > 0) {
                 String val = value.get(0);
-                if (key.endsWith(CODE)) {
+                if (key.endsWith(CODE) && (val != null)) {
                     codeFound.append(val.toString());
                 }
             }
@@ -302,7 +269,6 @@ public class MyBMWTokenController {
         return codeFound.toString();
     }
 
-    @SuppressWarnings("null")
     private synchronized boolean updateTokenChina() {
         try {
             /**

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/JsonStringDeserializer.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/JsonStringDeserializer.java
@@ -17,8 +17,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeSessionsContainer;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeStatisticsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingSessionsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
 import org.openhab.binding.mybmw.internal.dto.remote.ExecutionStatusContainer;
 import org.openhab.binding.mybmw.internal.dto.vehicle.VehicleBase;
 import org.openhab.binding.mybmw.internal.dto.vehicle.VehicleStateContainer;
@@ -62,23 +62,23 @@ public interface JsonStringDeserializer {
         }
     }
 
-    public static ChargeStatisticsContainer getChargeStatistics(String chargeStatisticsJson) {
+    public static ChargingStatisticsContainer getChargeStatistics(String chargeStatisticsJson) {
         try {
-            ChargeStatisticsContainer chargeStatistics = deserializeString(chargeStatisticsJson,
-                    ChargeStatisticsContainer.class);
+            ChargingStatisticsContainer chargeStatistics = deserializeString(chargeStatisticsJson,
+                    ChargingStatisticsContainer.class);
             return chargeStatistics;
         } catch (JsonSyntaxException e) {
             LOGGER.warn("JsonSyntaxException {}", e.getMessage());
-            return new ChargeStatisticsContainer();
+            return new ChargingStatisticsContainer();
         }
     }
 
-    public static ChargeSessionsContainer getChargeSessions(String chargeSessionsJson) {
+    public static ChargingSessionsContainer getChargeSessions(String chargeSessionsJson) {
         try {
-            return deserializeString(chargeSessionsJson, ChargeSessionsContainer.class);
+            return deserializeString(chargeSessionsJson, ChargingSessionsContainer.class);
         } catch (JsonSyntaxException e) {
             LOGGER.warn("JsonSyntaxException {}", e.getMessage());
-            return new ChargeSessionsContainer();
+            return new ChargingSessionsContainer();
         }
     }
 

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
@@ -30,8 +30,8 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.UrlEncoded;
 import org.openhab.binding.mybmw.internal.MyBMWBridgeConfiguration;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeSessionsContainer;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeStatisticsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingSessionsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
 import org.openhab.binding.mybmw.internal.dto.network.NetworkException;
 import org.openhab.binding.mybmw.internal.dto.remote.ExecutionStatusContainer;
 import org.openhab.binding.mybmw.internal.dto.vehicle.Vehicle;
@@ -166,7 +166,7 @@ public class MyBMWProxy {
      * request charge statistics for electric vehicles
      *
      */
-    public ChargeStatisticsContainer requestChargeStatistics(String vin, String brand) throws NetworkException {
+    public ChargingStatisticsContainer requestChargeStatistics(String vin, String brand) throws NetworkException {
         MultiMap<@Nullable String> chargeStatisticsParams = new MultiMap<>();
         chargeStatisticsParams.put("vin", vin);
         chargeStatisticsParams.put("currentDate", Converter.getCurrentISOTime());
@@ -182,7 +182,7 @@ public class MyBMWProxy {
      * request charge sessions for electric vehicles
      *
      */
-    public ChargeSessionsContainer requestChargeSessions(String vin, String brand) throws NetworkException {
+    public ChargingSessionsContainer requestChargeSessions(String vin, String brand) throws NetworkException {
         MultiMap<@Nullable String> chargeSessionsParams = new MultiMap<>();
         chargeSessionsParams.put("vin", vin);
         chargeSessionsParams.put("maxResults", "40");

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
@@ -49,10 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link MyBMWProxy} This class holds the important constants for the BMW
- * Connected Drive Authorization.
- * They
- * are taken from the Bimmercode from github
+ * The {@link MyBMWProxy} This class holds the important constants for the BMW Connected Drive Authorization.
+ * They are taken from the Bimmercode from github
  * {@link https://github.com/bimmerconnected/bimmer_connected}
  * File defining these constants
  * {@link https://github.com/bimmerconnected/bimmer_connected/blob/master/bimmer_connected/account.py}
@@ -169,7 +167,7 @@ public class MyBMWProxy {
      *
      */
     public ChargeStatisticsContainer requestChargeStatistics(String vin, String brand) throws NetworkException {
-        MultiMap<String> chargeStatisticsParams = new MultiMap<String>();
+        MultiMap<@Nullable String> chargeStatisticsParams = new MultiMap<>();
         chargeStatisticsParams.put("vin", vin);
         chargeStatisticsParams.put("currentDate", Converter.getCurrentISOTime());
         String params = UrlEncoded.encode(chargeStatisticsParams, StandardCharsets.UTF_8, false);
@@ -185,7 +183,7 @@ public class MyBMWProxy {
      *
      */
     public ChargeSessionsContainer requestChargeSessions(String vin, String brand) throws NetworkException {
-        MultiMap<String> chargeSessionsParams = new MultiMap<String>();
+        MultiMap<@Nullable String> chargeSessionsParams = new MultiMap<>();
         chargeSessionsParams.put("vin", vin);
         chargeSessionsParams.put("maxResults", "40");
         chargeSessionsParams.put("include_date_picker", "true");
@@ -258,7 +256,7 @@ public class MyBMWProxy {
      * @return
      */
     private synchronized byte[] call(final String url, final boolean post, final String brand,
-            final @Nullable String vin, String contentType, @Nullable String body) throws NetworkException {
+            final @Nullable String vin, final String contentType, final @Nullable String body) throws NetworkException {
         byte[] responseByteArray = "".getBytes();
 
         // return in case of unknown brand

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxy.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
  * @author Bernd Weymann - Initial contribution
  * @author Norbert Truchsess - edit & send of charge profile
  * @author Martin Grassl - refactoring
+ * @author Mark Herwege - extended log anonymization 
  */
 @NonNullByDefault
 public class MyBMWProxy {

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/ResponseContentAnonymizer.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/backend/ResponseContentAnonymizer.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  * @author Bernd Weymann - Initial contribution
  * @author Martin Grassl - refactoring & extension for any occurrence
+ * @author Mark Herwege - extended log anonymization 
  */
 @NonNullByDefault
 public interface ResponseContentAnonymizer {

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/enums/RemoteService.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/handler/enums/RemoteService.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * possible remote services
  *
  * @author Martin Grassl - initial contribution
+ * @author Mark Herwege - electric charging commands 
  */
 @NonNullByDefault
 public enum RemoteService {

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/utils/ChargingProfileUtils.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/utils/ChargingProfileUtils.java
@@ -22,15 +22,15 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey;
+import org.openhab.binding.mybmw.internal.utils.ChargingProfileWrapper.ProfileKey;
 
 /**
- * The {@link ChargeProfileUtils} utility functions for charging profiles
+ * The {@link ChargingProfileUtils} utility functions for charging profiles
  *
  * @author Norbert Truchsess - initial contribution
  */
 @NonNullByDefault
-public class ChargeProfileUtils {
+public class ChargingProfileUtils {
 
     // Charging
     public static class TimedChannel {

--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/utils/ChargingProfileWrapper.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/utils/ChargingProfileWrapper.java
@@ -12,14 +12,8 @@
  */
 package org.openhab.binding.mybmw.internal.utils;
 
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.TIMER1;
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.TIMER2;
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.TIMER3;
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.TIMER4;
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.WINDOWEND;
-import static org.openhab.binding.mybmw.internal.utils.ChargeProfileWrapper.ProfileKey.WINDOWSTART;
-import static org.openhab.binding.mybmw.internal.utils.Constants.NULL_LOCAL_TIME;
-import static org.openhab.binding.mybmw.internal.utils.Constants.TIME_FORMATER;
+import static org.openhab.binding.mybmw.internal.utils.ChargingProfileWrapper.ProfileKey.*;
+import static org.openhab.binding.mybmw.internal.utils.Constants.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -43,20 +37,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link ChargeProfileWrapper} Wrapper for ChargeProfiles
+ * The {@link ChargingProfileWrapper} Wrapper for ChargingProfiles
  *
  * @author Bernd Weymann - Initial contribution
  * @author Norbert Truchsess - add ChargeProfileActions
  * @author Martin Grassl - refactoring
  */
 @NonNullByDefault
-public class ChargeProfileWrapper {
-    private final Logger logger = LoggerFactory.getLogger(ChargeProfileWrapper.class);
+public class ChargingProfileWrapper {
+    private final Logger logger = LoggerFactory.getLogger(ChargingProfileWrapper.class);
 
-    private static final String CHARGING_WINDOW = "chargingWindow";
-    private static final String WEEKLY_PLANNER = "weeklyPlanner";
-    private static final String ACTIVATE = "activate";
-    private static final String DEACTIVATE = "deactivate";
+    private static final String CHARGING_WINDOW = "CHARGING_WINDOW";
+    private static final String WEEKLY_PLANNER = "WEEKLY_PLANNER";
+    private static final String ACTIVATE = "ACTIVATE";
+    private static final String DEACTIVATE = "DEACTIVATE";
 
     public enum ProfileKey {
         CLIMATE,
@@ -77,12 +71,12 @@ public class ChargeProfileWrapper {
     private final Map<ProfileKey, LocalTime> times = new HashMap<>();
     private final Map<ProfileKey, Set<DayOfWeek>> daysOfWeek = new HashMap<>();
 
-    public ChargeProfileWrapper(final ChargingProfile profile) {
+    public ChargingProfileWrapper(final ChargingProfile profile) {
         setPreference(profile.getChargingPreference());
         setMode(profile.getChargingMode());
         controlType = Optional.of(profile.getChargingControlType());
         chargeSettings = Optional.of(profile.getChargingSettings());
-        // setEnabled(CLIMATE, profile.climatisationOn);
+        setEnabled(ProfileKey.CLIMATE, profile.isClimatisationOn());
 
         addTimer(TIMER1, profile.getTimerId(1));
         addTimer(TIMER2, profile.getTimerId(2));
@@ -124,7 +118,7 @@ public class ChargeProfileWrapper {
         return controlType.get();
     }
 
-    public @Nullable ChargingSettings getChargeSettings() {
+    public @Nullable ChargingSettings getChargingSettings() {
         return chargeSettings.get();
     }
 

--- a/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/ev-vehicle-status-group.xml
+++ b/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/ev-vehicle-status-group.xml
@@ -15,7 +15,7 @@
 			<channel id="check-control" typeId="check-control-channel"/>
 			<channel id="plug-connection" typeId="plug-connection-channel"/>
 			<channel id="charge" typeId="charging-status-channel"/>
-			<channel id="charge-info" typeId="charging-info-channel"/>
+			<channel id="charge-remaining" typeId="charging-remaining-channel"/>
 			<channel id="last-update" typeId="last-update-channel"/>
 			<channel id="raw" typeId="raw-channel"/>
 		</channels>

--- a/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/vehicle-status-channel-types.xml
+++ b/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/vehicle-status-channel-types.xml
@@ -37,10 +37,10 @@
 		<label>Charging Status</label>
 		<state readOnly="true"/>
 	</channel-type>
-	<channel-type id="charging-info-channel">
-		<item-type>String</item-type>
-		<label>Charging Information</label>
-		<state readOnly="true"/>
+	<channel-type id="charging-remaining-channel">
+		<item-type>Number:Time</item-type>
+		<label>Remaining Charging Time</label>
+        <state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="plug-connection-channel">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/vehicle-status-channel-types.xml
+++ b/bundles/org.openhab.binding.mybmw/src/main/resources/OH-INF/thing/vehicle-status-channel-types.xml
@@ -40,7 +40,7 @@
 	<channel-type id="charging-remaining-channel">
 		<item-type>Number:Time</item-type>
 		<label>Remaining Charging Time</label>
-        <state pattern="%d %unit%" readOnly="true"/>
+		<state pattern="%d %unit%" readOnly="true"/>
 	</channel-type>
 	<channel-type id="plug-connection-channel">
 		<item-type>String</item-type>

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/ChargeStatisticWrapper.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/ChargeStatisticWrapper.java
@@ -27,7 +27,7 @@ import javax.measure.quantity.Energy;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeStatisticsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
 import org.openhab.binding.mybmw.internal.handler.backend.JsonStringDeserializer;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
@@ -45,14 +45,14 @@ import org.openhab.core.types.State;
 @NonNullByDefault
 @SuppressWarnings("null")
 public class ChargeStatisticWrapper {
-    private ChargeStatisticsContainer chargeStatisticContainer;
+    private ChargingStatisticsContainer chargeStatisticContainer;
 
     public ChargeStatisticWrapper(String content) {
-        ChargeStatisticsContainer fromJson = JsonStringDeserializer.getChargeStatistics(content);
+        ChargingStatisticsContainer fromJson = JsonStringDeserializer.getChargeStatistics(content);
         if (fromJson != null) {
             chargeStatisticContainer = fromJson;
         } else {
-            chargeStatisticContainer = new ChargeStatisticsContainer();
+            chargeStatisticContainer = new ChargingStatisticsContainer();
         }
     }
 

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
@@ -73,7 +73,7 @@ public class StatusWrapper {
     }
 
     /**
-     * Test results auctomatically against json values
+     * Test results automatically against json values
      *
      * @param channels
      * @param states
@@ -210,7 +210,7 @@ public class StatusWrapper {
                 assertTrue(isElectric, "Is Electric");
                 assertTrue(state instanceof QuantityType);
                 qt = ((QuantityType) state);
-                assertEquals(Units.MINUTE, qt.getUnit());
+                assertEquals(Units.MINUTE, qt.getUnit(), "Minute Unit");
                 assertEquals(vehicleState.getElectricChargingState().getRemainingChargingMinutes(), qt.intValue(),
                         "Charge Time Remaining");
                 break;

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
@@ -12,60 +12,8 @@
  */
 package org.openhab.binding.mybmw.internal.dto;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.ADDRESS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHANNEL_GROUP_CHARGE_PROFILE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHANNEL_GROUP_CHECK_CONTROL;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHANNEL_GROUP_RANGE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHANNEL_GROUP_SERVICE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHANNEL_GROUP_STATUS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHARGE_INFO;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHARGE_STATUS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.CHECK_CONTROL;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DATE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DETAILS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DOORS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DOOR_DRIVER_FRONT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DOOR_DRIVER_REAR;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DOOR_PASSENGER_FRONT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.DOOR_PASSENGER_REAR;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.FRONT_LEFT_CURRENT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.FRONT_LEFT_TARGET;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.FRONT_RIGHT_CURRENT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.FRONT_RIGHT_TARGET;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.GPS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.HEADING;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.HOME_DISTANCE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.HOOD;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.LAST_UPDATE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.LOCK;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.MILEAGE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.NAME;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.PLUG_CONNECTION;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.RANGE_ELECTRIC;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.RANGE_FUEL;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.RANGE_RADIUS_ELECTRIC;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.RANGE_RADIUS_FUEL;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.RAW;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.REAR_LEFT_CURRENT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.REAR_LEFT_TARGET;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.REAR_RIGHT_CURRENT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.REAR_RIGHT_TARGET;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.REMAINING_FUEL;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.SERVICE_DATE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.SERVICE_MILEAGE;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.SEVERITY;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.SOC;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.SUNROOF;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.TRUNK;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.WINDOWS;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.WINDOW_DOOR_DRIVER_FRONT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.WINDOW_DOOR_DRIVER_REAR;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.WINDOW_DOOR_PASSENGER_FRONT;
-import static org.openhab.binding.mybmw.internal.MyBMWConstants.WINDOW_DOOR_PASSENGER_REAR;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openhab.binding.mybmw.internal.MyBMWConstants.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -258,11 +206,13 @@ public class StatusWrapper {
                     assertEquals(wanted.toString(), st.toString(), "Check Control");
                 }
                 break;
-            case CHARGE_INFO:
+            case CHARGE_REMAINING:
                 assertTrue(isElectric, "Is Electric");
-                assertTrue(state instanceof StringType);
-                st = (StringType) state;
-                assertEquals(StringType.valueOf(Constants.UNDEF), st.toString(), "Charge Info");
+                assertTrue(state instanceof QuantityType);
+                qt = ((QuantityType) state);
+                assertEquals(Units.MINUTE, qt.getUnit());
+                assertEquals(vehicleState.getElectricChargingState().getRemainingChargingMinutes(), qt.intValue(),
+                        "Charge Time Remaining");
                 break;
             case CHARGE_STATUS:
                 assertTrue(isElectric, "Is Electric");

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/StatusWrapper.java
@@ -49,6 +49,7 @@ import org.openhab.core.types.UnDefType;
  *
  * @author Bernd Weymann - Initial contribution
  * @author Martin Grassl - updates for v2 API
+ * @author Mark Herwege - remaining charging time test
  */
 @NonNullByDefault
 @SuppressWarnings("null")

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/charge/ChargeStatisticsTest.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/dto/charge/ChargeStatisticsTest.java
@@ -112,7 +112,7 @@ public class ChargeStatisticsTest {
 
         try {
             Method updateChargeStatisticsMethod = VehicleHandler.class.getDeclaredMethod("updateChargeStatistics",
-                    ChargeStatisticsContainer.class);
+                    ChargingStatisticsContainer.class);
             updateChargeStatisticsMethod.invoke(vehicleHandler,
                     JsonStringDeserializer.getChargeStatistics(statusContent));
         } catch (Exception e) {

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/handler/VehicleHandlerTest.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/handler/VehicleHandlerTest.java
@@ -12,15 +12,8 @@
  */
 package org.openhab.binding.mybmw.internal.handler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxyBackendIT.java
+++ b/bundles/org.openhab.binding.mybmw/src/test/java/org/openhab/binding/mybmw/internal/handler/backend/MyBMWProxyBackendIT.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openhab.binding.mybmw.internal.MyBMWBridgeConfiguration;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeSessionsContainer;
-import org.openhab.binding.mybmw.internal.dto.charge.ChargeStatisticsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingSessionsContainer;
+import org.openhab.binding.mybmw.internal.dto.charge.ChargingStatisticsContainer;
 import org.openhab.binding.mybmw.internal.dto.network.NetworkException;
 import org.openhab.binding.mybmw.internal.dto.remote.ExecutionStatusContainer;
 import org.openhab.binding.mybmw.internal.dto.vehicle.Vehicle;
@@ -125,7 +125,7 @@ public class MyBMWProxyBackendIT {
             assertNotNull(vehicleState);
 
             // get charge statistics -> only successful for electric vehicles
-            ChargeStatisticsContainer chargeStatisticsContainer = null;
+            ChargingStatisticsContainer chargeStatisticsContainer = null;
             try {
                 chargeStatisticsContainer = myBMWProxy.requestChargeStatistics(vehicleBase.getVin(),
                         vehicleBase.getAttributes().getBrand());
@@ -133,7 +133,7 @@ public class MyBMWProxyBackendIT {
                 logger.trace("error: {}", e.toString());
             }
 
-            ChargeSessionsContainer chargeSessionsContainer = null;
+            ChargingSessionsContainer chargeSessionsContainer = null;
             try {
                 chargeSessionsContainer = myBMWProxy.requestChargeSessions(vehicleBase.getVin(),
                         vehicleBase.getAttributes().getBrand());

--- a/bundles/org.openhab.binding.mybmw/src/test/resources/responses/BEV/vehicles_state.json
+++ b/bundles/org.openhab.binding.mybmw/src/test/resources/responses/BEV/vehicles_state.json
@@ -176,11 +176,12 @@
             }
         },
         "electricChargingState": {
-            "chargingLevelPercent": 57,
-            "range": 191,
-            "isChargerConnected": false,
+            "chargingLevelPercent": 46,
+            "remainingChargingMinutes": 178,
+            "range": 159,
+            "isChargerConnected": true,
             "chargingConnectionType": "UNKNOWN",
-            "chargingStatus": "INVALID",
+            "chargingStatus": "CHARGING",
             "chargingTarget": 80
         },
         "combustionFuelLevel": {


### PR DESCRIPTION
Charging windows and AC schedules were not working. I fixed these. When doing that, I also renamed a number of classes (Charge into Charging) to match with the json structures.
These charging schedules may still require more work. I will need to test extensively over a few days.

The charging-info channel could indeed not be mapped directly anymore. All info is available in other fields. I therefore replaced it by the one missing field: the remaining charging time.