### PR TITLE
Fix jsonArray no such method exception

### DIFF
--- a/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
+++ b/bundles/org.openhab.binding.mybmw/src/main/java/org/openhab/binding/mybmw/internal/console/MyBMWCommandExtension.java
@@ -234,7 +234,7 @@ public class MyBMWCommandExtension extends AbstractConsoleCommandExtension {
     private void writeJsonToFile(String pathString, String filename, String json) throws IOException {
         try {
             JsonElement element = JsonParser.parseString(json);
-            if (element.isJsonNull() || (element.isJsonArray() && ((JsonArray) element).isEmpty())) {
+            if (element.isJsonNull() || (element.isJsonArray() && ((JsonArray) element).size() > 0)) {
                 // Don't write a file if empty
                 return;
             }


### PR DESCRIPTION
IsEmpty() only available with gson starting version 2.8.7.

